### PR TITLE
break dependency on tokio-test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,3 @@ edition = "2018"
 
 [dependencies]
 tokio = { version = "^0.2.23", features = ["tcp", "sync", "io-util", "io-std", "time", "rt-core", "rt-threaded", "macros"] }
-poll_macros = { git = "https://github.com/stepfunc/poll_macros.git" }
-
-[dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,6 @@ edition = "2018"
 
 [dependencies]
 tokio = { version = "^0.2.23", features = ["tcp", "sync", "io-util", "io-std", "time", "rt-core", "rt-threaded", "macros"] }
-tokio-test = "0.3"
+poll_macros = { git = "https://github.com/stepfunc/poll_macros.git" }
+
+[dev-dependencies]

--- a/src/mock/mod.rs
+++ b/src/mock/mod.rs
@@ -13,11 +13,11 @@ pub use tokio::spawn;
 
 #[cfg(test)]
 mod tests {
+    use crate::mock::test::*;
     use std::future::Future;
     use std::time::Duration;
 
     use super::*;
-    use tokio_test::*;
 
     #[test]
     fn select_message_before_timeout() {
@@ -26,7 +26,7 @@ mod tests {
         let mut select_task = select_task(rx);
 
         assert_pending!(select_task.poll());
-        assert_ready_ok!(task::spawn(async { tx.send(42).await }).poll());
+        assert_ready_ok!(crate::mock::test::spawn(async { tx.send(42).await }).poll());
         assert_ready_eq!(select_task.poll(), Some(42));
     }
 
@@ -41,10 +41,8 @@ mod tests {
         assert_ready_eq!(select_task.poll(), None);
     }
 
-    fn select_task(
-        mut rx: sync::mpsc::Receiver<u32>,
-    ) -> task::Spawn<impl Future<Output = Option<u32>>> {
-        task::spawn(async move {
+    fn select_task(mut rx: sync::mpsc::Receiver<u32>) -> Spawn<impl Future<Output = Option<u32>>> {
+        crate::mock::test::spawn(async move {
             tokio::select! {
                 _ = time::delay_for(Duration::from_secs(1)) => {
                     None

--- a/src/mock/sync/oneshot.rs
+++ b/src/mock/sync/oneshot.rs
@@ -161,13 +161,14 @@ pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tokio_test::*;
+
+    use crate::mock::test::*;
 
     #[test]
     fn send_recv() {
         let (tx, rx) = channel();
 
-        let mut rx_task = task::spawn(async move { rx.await });
+        let mut rx_task = spawn(async move { rx.await });
 
         assert_pending!(rx_task.poll());
         assert!(tx.send(42).is_ok());
@@ -178,7 +179,7 @@ mod tests {
     fn dropping_tx() {
         let (tx, rx) = channel::<()>();
 
-        let mut rx_task = task::spawn(async { rx.await });
+        let mut rx_task = spawn(async { rx.await });
 
         assert_pending!(rx_task.poll());
         drop(tx);
@@ -208,7 +209,7 @@ mod tests {
     fn send_closed() {
         let (mut tx, rx) = channel::<()>();
 
-        let mut closed_task = task::spawn(async move { tx.closed().await });
+        let mut closed_task = spawn(async move { tx.closed().await });
 
         assert_pending!(closed_task.poll());
         drop(rx);

--- a/src/mock/test/macros.rs
+++ b/src/mock/test/macros.rs
@@ -1,0 +1,210 @@
+/// Asserts a `Poll` is ready, returning the value.
+///
+/// This will invoke `panic!` if the provided `Poll` does not evaluate to `Poll::Ready` at
+/// runtime.
+///
+/// # Custom Messages
+///
+/// This macro has a second form, where a custom panic message can be provided with or without
+/// arguments for formatting.
+///
+/// ```
+#[macro_export]
+macro_rules! assert_ready {
+    ($e:expr) => {{
+        use core::task::Poll::*;
+        match $e {
+            Ready(v) => v,
+            Pending => panic!("pending"),
+        }
+    }};
+    ($e:expr, $($msg:tt)+) => {{
+        use core::task::Poll::*;
+        match $e {
+            Ready(v) => v,
+            Pending => {
+                panic!("pending; {}", format_args!($($msg)+))
+            }
+        }
+    }};
+}
+
+/// Asserts a `Poll<Result<...>>` is ready and `Ok`, returning the value.
+///
+/// This will invoke `panic!` if the provided `Poll` does not evaluate to `Poll::Ready(Ok(..))` at
+/// runtime.
+///
+/// # Custom Messages
+///
+/// This macro has a second form, where a custom panic message can be provided with or without
+/// arguments for formatting.
+///
+/// ```
+#[macro_export]
+macro_rules! assert_ready_ok {
+    ($e:expr) => {{
+        use $crate::{assert_ready, assert_ok};
+        let val = assert_ready!($e);
+        assert_ok!(val)
+    }};
+    ($e:expr, $($msg:tt)+) => {{
+        use $crate::{assert_ready, assert_ok};
+        let val = assert_ready!($e, $($msg)*);
+        assert_ok!(val, $($msg)*)
+    }};
+}
+
+/// Asserts a `Poll<Result<...>>` is ready and `Err`, returning the error.
+///
+/// This will invoke `panic!` if the provided `Poll` does not evaluate to `Poll::Ready(Err(..))` at
+/// runtime.
+///
+/// # Custom Messages
+///
+/// This macro has a second form, where a custom panic message can be provided with or without
+/// arguments for formatting.
+///
+/// ```
+#[macro_export]
+macro_rules! assert_ready_err {
+    ($e:expr) => {{
+        use $crate::{assert_ready, assert_err};
+        let val = assert_ready!($e);
+        assert_err!(val)
+    }};
+    ($e:expr, $($msg:tt)+) => {{
+        use $crate::{assert_ready, assert_err};
+        let val = assert_ready!($e, $($msg)*);
+        assert_err!(val, $($msg)*)
+    }};
+}
+
+/// Asserts a `Poll` is pending.
+///
+/// This will invoke `panic!` if the provided `Poll` does not evaluate to `Poll::Pending` at
+/// runtime.
+///
+/// # Custom Messages
+///
+/// This macro has a second form, where a custom panic message can be provided with or without
+/// arguments for formatting.
+///
+/// ```
+#[macro_export]
+macro_rules! assert_pending {
+    ($e:expr) => {{
+        use core::task::Poll::*;
+        match $e {
+            Pending => {}
+            Ready(v) => panic!("ready; value = {:?}", v),
+        }
+    }};
+    ($e:expr, $($msg:tt)+) => {{
+        use core::task::Poll::*;
+        match $e {
+            Pending => {}
+            Ready(v) => {
+                panic!("ready; value = {:?}; {}", v, format_args!($($msg)+))
+            }
+        }
+    }};
+}
+
+/// Asserts if a poll is ready and check for equality on the value
+///
+/// This will invoke `panic!` if the provided `Poll` does not evaluate to `Poll::Ready` at
+/// runtime and the value produced does not partially equal the expected value.
+///
+/// # Custom Messages
+///
+/// This macro has a second form, where a custom panic message can be provided with or without
+/// arguments for formatting.
+///
+/// ```
+#[macro_export]
+macro_rules! assert_ready_eq {
+    ($e:expr, $expect:expr) => {
+        let val = $crate::assert_ready!($e);
+        assert_eq!(val, $expect)
+    };
+
+    ($e:expr, $expect:expr, $($msg:tt)+) => {
+        let val = $crate::assert_ready!($e, $($msg)*);
+        assert_eq!(val, $expect, $($msg)*)
+    };
+}
+
+/// Asserts that the expression evaluates to `Ok` and returns the value.
+///
+/// This will invoke the `panic!` macro if the provided expression does not evaluate to `Ok` at
+/// runtime.
+///
+/// # Custom Messages
+///
+/// This macro has a second form, where a custom panic message can be provided with or without
+/// arguments for formatting.
+///
+/// ```
+#[macro_export]
+macro_rules! assert_ok {
+    ($e:expr) => {
+        assert_ok!($e,)
+    };
+    ($e:expr,) => {{
+        use core::result::Result::*;
+        match $e {
+            Ok(v) => v,
+            Err(e) => panic!("assertion failed: Err({:?})", e),
+        }
+    }};
+    ($e:expr, $($arg:tt)+) => {{
+        use core::result::Result::*;
+        match $e {
+            Ok(v) => v,
+            Err(e) => panic!("assertion failed: Err({:?}): {}", e, format_args!($($arg)+)),
+        }
+    }};
+}
+
+/// Asserts that the expression evaluates to `Err` and returns the error.
+///
+/// This will invoke the `panic!` macro if the provided expression does not evaluate to `Err` at
+/// runtime.
+///
+/// # Custom Messages
+///
+/// This macro has a second form, where a custom panic message can be provided with or without
+/// arguments for formatting.
+///
+/// # Examples
+///
+/// ```
+/// use tokio_mock::assert_err;
+/// use std::str::FromStr;
+///
+///
+/// let err = assert_err!(u32::from_str("fail"));
+///
+/// let msg = "fail";
+/// let err = assert_err!(u32::from_str(msg), "testing parsing {:?} as u32", msg);
+/// ```
+#[macro_export]
+macro_rules! assert_err {
+    ($e:expr) => {
+        assert_err!($e,);
+    };
+    ($e:expr,) => {{
+        use core::result::Result::*;
+        match $e {
+            Ok(v) => panic!("assertion failed: Ok({:?})", v),
+            Err(e) => e,
+        }
+    }};
+    ($e:expr, $($arg:tt)+) => {{
+        use core::result::Result::*;
+        match $e {
+            Ok(v) => panic!("assertion failed: Ok({:?}): {}", v, format_args!($($arg)+)),
+            Err(e) => e,
+        }
+    }};
+}

--- a/src/mock/test/mod.rs
+++ b/src/mock/test/mod.rs
@@ -1,15 +1,16 @@
 pub mod io;
-
-pub use poll_macros::assert_err;
-pub use poll_macros::assert_ok;
-pub use poll_macros::assert_pending;
-pub use poll_macros::assert_ready;
-pub use poll_macros::assert_ready_eq;
-pub use poll_macros::assert_ready_err;
-pub use poll_macros::assert_ready_ok;
+mod macros;
 
 use std::ptr::null;
 use std::task::{Context, RawWaker, Waker};
+
+pub use crate::assert_ready;
+pub use crate::assert_ready_ok;
+pub use crate::assert_ready_err;
+pub use crate::assert_pending;
+pub use crate::assert_ready_eq;
+pub use crate::assert_ok;
+pub use crate::assert_err;
 
 pub struct Spawn<T>
 where

--- a/src/mock/test/mod.rs
+++ b/src/mock/test/mod.rs
@@ -1,8 +1,54 @@
 pub mod io;
 
-// Re-exports from tokio_test
-pub use tokio_test::assert_pending;
-pub use tokio_test::assert_ready;
-pub use tokio_test::assert_ready_eq;
+pub use poll_macros::assert_err;
+pub use poll_macros::assert_ok;
+pub use poll_macros::assert_pending;
+pub use poll_macros::assert_ready;
+pub use poll_macros::assert_ready_eq;
+pub use poll_macros::assert_ready_err;
+pub use poll_macros::assert_ready_ok;
 
-pub use tokio_test::task::{spawn, Spawn};
+use std::ptr::null;
+use std::task::{Context, RawWaker, Waker};
+
+pub struct Spawn<T>
+where
+    T: std::future::Future,
+{
+    future: std::pin::Pin<Box<T>>,
+}
+
+impl<T> Spawn<T>
+where
+    T: std::future::Future,
+{
+    pub fn poll(&mut self) -> std::task::Poll<T::Output> {
+        let waker = unsafe { Waker::from_raw(RawWaker::new(null(), &details::NULL_WAKER_VTABLE)) };
+        let mut context = Context::from_waker(&waker);
+        self.future.as_mut().poll(&mut context)
+    }
+}
+
+pub fn spawn<T>(f: T) -> Spawn<T>
+where
+    T: std::future::Future,
+{
+    Spawn {
+        future: Box::pin(f),
+    }
+}
+
+pub(crate) mod details {
+    use std::ptr::null;
+    use std::task::{RawWaker, RawWakerVTable};
+
+    fn clone(_: *const ()) -> RawWaker {
+        RawWaker::new(null(), &NULL_WAKER_VTABLE)
+    }
+    fn wake(_: *const ()) {}
+    fn wake_by_ref(_: *const ()) {}
+    fn drop(_: *const ()) {}
+
+    pub(crate) const NULL_WAKER_VTABLE: RawWakerVTable =
+        RawWakerVTable::new(clone, wake, wake_by_ref, drop);
+}


### PR DESCRIPTION
Adds a custom `spawn` method with a custom Spawn type that can be polled without an external content. Internally uses a null Context/Waker since the tests don't need anything real.

All of the macros from `tokio_test` are put an external fork crate called "poll-macros" which are re-exported from this crate.