### PR TITLE
expose task module

### DIFF
--- a/src/mock/mod.rs
+++ b/src/mock/mod.rs
@@ -11,6 +11,11 @@ pub use tokio::select;
 // to poll manually.
 pub use tokio::spawn;
 
+// we don't mock the types in Task
+pub mod task {
+    pub use tokio::task::*;
+}
+
 #[cfg(test)]
 mod tests {
     use crate::mock::test::*;

--- a/src/real.rs
+++ b/src/real.rs
@@ -8,6 +8,10 @@ pub mod io {
     pub use io::{Error, ErrorKind, Result};
 }
 
+pub mod task {
+    pub use tokio::task::*;
+}
+
 pub mod time {
     use tokio::time;
 


### PR DESCRIPTION
exposes all the types in the 'task' module without mocking them.